### PR TITLE
Use a brighter color for title readability

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 
 	"theme": {
 		"colors": {
-			"frame": [83, 152, 236],
+			"frame": [133, 177, 235],
 			"frame_inactive": [158, 194, 239],
 			"frame_incognito": [87, 112, 151],
 			"frame_incognito_inactive": [132, 145, 166],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 
-	"name": "Material Classic Blue Theme",	
+	"name": "Material Classic Blue Theme",
 	"description": "A flat Classic Blue theme for Chrome.",
 	"version": "4.0.0",
 


### PR DESCRIPTION
This change will

* have better support with chrome v69
* make the tab title easier to read

### Current web store version

* Problem: the border of tabs when window is focused

![original-focus](https://user-images.githubusercontent.com/356911/45302315-8f848e00-b545-11e8-8e81-ac0fe0d1a666.png)
![original-inactive](https://user-images.githubusercontent.com/356911/45302314-8eebf780-b545-11e8-85d8-e681b8843893.png)

### Current md2 branch

* Problem: when switching among windows, the color of tab text changes between black and white. A bit annoying. Setting to black will result in low readability.

![md2-focus](https://user-images.githubusercontent.com/356911/45302593-4da81780-b546-11e8-9507-cb5ede8f08a3.png)
![md2-inactive](https://user-images.githubusercontent.com/356911/45302592-4d0f8100-b546-11e8-950e-aa4aa2bb0935.png)

### After this change

* The new color is not from classic blue. But I've tried to come up with a suitable color.

![new-focus](https://user-images.githubusercontent.com/356911/45302176-31f04180-b545-11e8-9044-6f4dde3c9541.png)
![new-inactive](https://user-images.githubusercontent.com/356911/45302174-31f04180-b545-11e8-8d1b-d692281af318.png)

### Chrome v69 default theme

![default-focus](https://user-images.githubusercontent.com/356911/45302178-3288d800-b545-11e8-8ec6-40b6870d46ba.png)
![default-inactive](https://user-images.githubusercontent.com/356911/45302177-31f04180-b545-11e8-8522-c95e85c10b83.png)